### PR TITLE
Add new users after edit group

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -23,8 +23,13 @@ class GroupsController < ApplicationController
 
   def update
     group = Group.find(params[:id])
-        group.update(create_params)
-        redirect_to :root
+    if group.update(create_params)
+      flash[:notice] = "変更を登録しました"
+      redirect_to :root
+    else
+      flash[:alert] = "変更を登録できませんでした"
+      redirect_to edit_group_path
+    end
   end
 
   private

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -24,12 +24,10 @@ class GroupsController < ApplicationController
   def update
     group = Group.find(params[:id])
     if group.update(create_params)
-      flash[:notice] = "変更を登録しました"
-      redirect_to :root
+      redirect_to :root, flash[:notice] = "変更を登録しました"
     else
       flash[:alert] = "変更を登録できませんでした"
       redirect_to edit_group_path
-    end
   end
 
   private

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -9,11 +9,9 @@ class GroupsController < ApplicationController
   def create
     @group = Group.new(create_params)
     if @group.save
-      flash[:notice] = "グループを作成しました"
-      redirect_to :root
+      redirect_to :root, flash[:notice] = "グループを作成しました"
     else
-      flash[:alert] = "グループを作成できませんでした"
-      redirect_to new_group_path
+      redirect_to new_group_path, flash[:alert] = "グループを作成できませんでした"
     end
   end
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -26,8 +26,7 @@ class GroupsController < ApplicationController
     if group.update(create_params)
       redirect_to :root, flash[:notice] = "変更を登録しました"
     else
-      flash[:alert] = "変更を登録できませんでした"
-      redirect_to edit_group_path
+      redirect_to edit_group_path, flash[:alert] = "変更を登録できませんでした"
   end
 
   private

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -16,6 +16,12 @@
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
         = f.label :チャットメンバー, class:'chat-group-form__label'
+      .chat-group-form__field--right
+        #chat-group-users
+          .chat-group-user.clearfix
+            %p.chat-group-user__name
+            = f.collection_check_boxes(:user_ids, User.all, :id, :name) do |t|
+              = t.label { t.check_box + t.text }
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
       .chat-group-form__field--right

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -18,7 +18,7 @@
         = f.label :チャットメンバー, class:'chat-group-form__label'
       .chat-group-form__field--right
         #chat-group-users
-          #chat-group-user-22.chat-group-user.clearfix
+          .chat-group-user.clearfix
             %p.chat-group-user__name
             = f.collection_check_boxes(:user_ids, User.all, :id, :name) do |t|
               = t.label { t.check_box + t.text }


### PR DESCRIPTION
## WHAT

グループ編集時にメンバーを追加する機能の実装

## WHY

ユーザビリティ向上のため